### PR TITLE
Disable compression to fix abnormal closure

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,7 +21,6 @@ type Client struct {
 func Connect(server string, userid string, username string) (*Client, error) {
 
 	dialer := &websocket.Dialer{}
-	dialer.EnableCompression = true
 	url := "ws://ws.generals.io/socket.io/?EIO=3&transport=websocket"
 
 	if server == "eu" {


### PR DESCRIPTION
I tried running your simplebot and it never joined the room. It turns out that the websocket was closing with an error code of 1006. I tried digging into the gorilla/websocket library to figure out exactly what's happening, but I didn't have much success.

On a whim, I tried disabling compression and it fixed the issue! I thought I would push it back.